### PR TITLE
not working with rspec 2.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Usage
 
 1. Copy the pre-commit hook file into your .git/hooks directory.
 2. Try to perform a git commit -m with a failing Rspect test.
+
+If the hook is not getting executed, call ```chmod +x .git/hooks/rspec-precommit``` to make it so!

--- a/rspec-precommit
+++ b/rspec-precommit
@@ -2,7 +2,7 @@
 require 'pty'
 html_path = "rspec_results.html"
 begin
-  PTY.spawn( "rake spec" ) do |stdin, stdout, pid|
+  PTY.spawn( "rspec spec --format h > rspec_results.html" ) do |stdin, stdout, pid|
   begin
     stdin.each { |line| print line }
   rescue Errno::EIO
@@ -23,7 +23,8 @@ pending = html.match(/(\d+) pending/)[0].to_i rescue 0
 
 if errors.zero?
   puts "0 failed! #{examples} run, #{pending} pending"
-  puts "View spec results at #{File.expand_path(html_path)}"
+  # HTML Output when tests ran successfully:
+  # puts "View spec results at #{File.expand_path(html_path)}"
   sleep 1
   exit 0
 else
@@ -31,6 +32,7 @@ else
   puts "View your rspec results at #{File.expand_path(html_path)}"
   puts
   puts "#{errors} failed! #{examples} run, #{pending} pending"
-  `open #{html_path}`
+  # Open HTML Ooutput when tests failed
+  # `open #{html_path}`
   exit 1
 end


### PR DESCRIPTION
the command `rake spec` is not working with  the current version of rspec on my system.
ruby: 2.0.0
rails: 3.2.13
rspec: 2.13.1

I updated the command to run `rspec spec` with html output option and added comments + some help to the read me
